### PR TITLE
Added <Plug>SchleppDup and <SID>SchleppDup.

### DIFF
--- a/plugin/schlepp.vim
+++ b/plugin/schlepp.vim
@@ -44,11 +44,13 @@ noremap <unique> <script> <Plug>SchleppUp <SID>SchleppUp
 noremap <unique> <script> <Plug>SchleppDown <SID>SchleppDown
 noremap <unique> <script> <Plug>SchleppLeft <SID>SchleppLeft
 noremap <unique> <script> <Plug>SchleppRight <SID>SchleppRight
+noremap <unique> <script> <Plug>SchleppDup <SID>SchleppDup
 
 noremap <SID>SchleppUp    :call <SID>Schlepp("Up")<CR>
 noremap <SID>SchleppDown  :call <SID>Schlepp("Down")<CR>
 noremap <SID>SchleppLeft  :call <SID>Schlepp("Left")<CR>
 noremap <SID>SchleppRight :call <SID>Schlepp("Right")<CR>
+noremap <SID>SchleppDup   :call <SID>SchleppDup()<CR>
 
 "Reindent Mappings
 "These are only done on VisualLine Mode


### PR DESCRIPTION
No-arg dup mappings. Rely on schlepp options for direction.

I was wondering why the following vmap, which I added to my vimrc, wasn't working:

```
vmap ,d <Plug>SchleppDup
```

I dug into the plugin code and found that <Plug>SchleppDup wasn't actually defined. So I added that and now my vmap works.
