### PR TITLE
Added <Plug>SchleppDup and <SID>SchleppDup.

### DIFF
--- a/plugin/schlepp.vim
+++ b/plugin/schlepp.vim
@@ -248,11 +248,13 @@ noremap <unique> <script> <Plug>SchleppDupUp <SID>SchleppDupUp
 noremap <unique> <script> <Plug>SchleppDupDown <SID>SchleppDupDown
 noremap <unique> <script> <Plug>SchleppDupLeft <SID>SchleppDupLeft
 noremap <unique> <script> <Plug>SchleppDupRight <SID>SchleppDupRight
+noremap <unique> <script> <Plug>SchleppDup <SID>SchleppDup
 
 noremap <SID>SchleppDupUp    :call <SID>SchleppDup("Up")<CR>
 noremap <SID>SchleppDupDown  :call <SID>SchleppDup("Down")<CR>
 noremap <SID>SchleppDupLeft  :call <SID>SchleppDup("Left")<CR>
 noremap <SID>SchleppDupRight :call <SID>SchleppDup("Right")<CR>
+noremap <SID>SchleppDup      :call <SID>SchleppDup()<CR>
 "}}}
 "{{{ s:SchleppDup(...) range
 function! s:SchleppDup(...) range


### PR DESCRIPTION
No-arg dup mappings. Rely on schlepp options for direction.

I was wondering why the following vmap, which I'd added to my vimrc, wasn't working:

```
vmap ,d <Plug>SchleppDup
```

Dug into the plugin code and found that <Plug>SchleppDup wasn't defined. So I added it and now my vmap works.
