### PR TITLE
Cleaned up all VINT errors. Fixed SchleppDupBlock(left) issue

### DIFF
--- a/plugin/schlepp.vim
+++ b/plugin/schlepp.vim
@@ -58,6 +58,12 @@ function! s:Schlepp(dir, ...) range
 "       Work with a count specifier eg. [count]<Up> moves lines count times
 "       Maybe: Make word with a motion
 
+    "Avoid errors in read-only buffers
+    if ! &modifiable
+        echo 'Read only buffer'
+        call s:ResetSelection()
+        return
+    endif
     "Get what visual mode was being used
     normal! gv
     let l:md = mode()
@@ -249,6 +255,13 @@ noremap <SID>SchleppDup      :call <SID>SchleppDup()<CR>
 "{{{ s:SchleppDup(...) range
 function! s:SchleppDup(...) range
 " Duplicates the selected lines/block of text
+
+    "Avoid errors in read-only buffers
+    if ! &modifiable
+        echo 'Read only buffer'
+        call s:ResetSelection()
+        return
+    endif
 
     "Get mode
     normal! gv

--- a/plugin/schlepp.vim
+++ b/plugin/schlepp.vim
@@ -16,7 +16,7 @@
 "   UndoJoin needs to not join between Line and Block modes (may not already - untested)
 "   Add padding function, that inserts a space or newline in the direction specified
 
-if exists("g:Schlepp#Loaded")
+if exists('g:Schlepp#Loaded')
     finish
 endif
 let g:Schlepp#Loaded = 1
@@ -59,7 +59,7 @@ function! s:Schlepp(dir, ...) range
 "       Maybe: Make word with a motion
 
     "Get what visual mode was being used
-    normal gv
+    normal! gv
     let l:md = mode()
     execute "normal! \<Esc>"
 
@@ -71,7 +71,7 @@ function! s:Schlepp(dir, ...) range
     endif
 
     "Branch off into specilized functions for each mode, check for undojoin
-    if l:md ==# "V"
+    if l:md ==# 'V'
         "Reindent if necessary
         if a:0 >= 1
             let l:reindent = a:1
@@ -84,7 +84,7 @@ function! s:Schlepp(dir, ...) range
         else
             call s:SchleppLines(a:dir, l:reindent)
         endif
-    elseif l:md ==# ""
+    elseif l:md ==# ''
         if s:CheckUndo(l:md)
             undojoin | call s:SchleppBlock(a:dir)
         else
@@ -99,41 +99,41 @@ function! s:SchleppLines(dir, reindent)
     "build normal command string to reselect the VisualLine area
     let l:fline = line("'<")
     let l:lline = line("'>")
-    let l:reindent_cmd = (a:reindent ? "gv=" : "")
+    let l:reindent_cmd = (a:reindent ? 'gv=' : '')
 
-    if a:dir ==? "up" "{{{ Up
+    if a:dir ==? 'up' "{{{ Up
         if l:fline == 1 "First lines of file, move everything else down
-            call append(l:lline, "")
+            call append(l:lline, '')
             call s:ResetSelection()
         else
-            execute "normal! :'<,'>m'<-2\<CR>" . l:reindent_cmd . "gv"
+            execute "normal! :'<,'>m'<-2\<CR>" . l:reindent_cmd . 'gv'
         endif "}}}
-    elseif a:dir ==? "down" "{{{ Down
-        if l:lline == line("$") "Moving down past EOF
-            call append(l:fline - 1, "")
+    elseif a:dir ==? 'down' "{{{ Down
+        if l:lline == line('$') "Moving down past EOF
+            call append(l:fline - 1, '')
             call s:ResetSelection()
         else
-            execute "normal! :'<,'>m'>+1\<CR>" . l:reindent_cmd . "gv"
+            execute "normal! :'<,'>m'>+1\<CR>" . l:reindent_cmd . 'gv'
         endif "}}}
-    elseif a:dir ==? "right" "{{{ Right
+    elseif a:dir ==? 'right' "{{{ Right
         if g:Schlepp#useShiftWidthLines
             normal! gv>
         else
             for l:linenum in range(l:fline, l:lline)
                 let l:line = getline(l:linenum)
                 "Only insert space if the line is not empty
-                if match(l:line, "^$") == -1
-                    call setline(linenum, " ".l:line)
+                if match(l:line, '^$') == -1
+                    call setline(l:linenum, ' '.l:line)
                 endif
             endfor
         endif
         call s:ResetSelection() "}}}
-    elseif a:dir ==? "left" "{{{ Left
+    elseif a:dir ==? 'left' "{{{ Left
         if g:Schlepp#useShiftWidthLines
             normal! gv<
         elseif g:Schlepp#allowSquishingLines || match(getline(l:fline, l:lline), '^[^ \t]') == -1
             for l:linenum in range(l:fline, l:lline)
-                call setline(l:linenum, substitute(getline(l:linenum), "^\\s", "", ""))
+                call setline(l:linenum, substitute(getline(l:linenum), "^\\s", '', ''))
             endfor
         endif
         call s:ResetSelection()
@@ -160,29 +160,29 @@ function! s:SchleppBlock(dir)
             let l:right_col -= 1
         endif
 
-        if a:dir ==? "up" "{{{ Up
+        if a:dir ==? 'up' "{{{ Up
             if l:fline == 1 "First lines of file
-                call append(0, "")
+                call append(0, '')
             endif
             normal! gvxkPgvkoko
             "}}}
-        elseif a:dir ==? "down" "{{{ Down
-            if l:lline == line("$") "Moving down past EOF
-                call append(line("$"), "")
+        elseif a:dir ==? 'down' "{{{ Down
+            if l:lline == line('$') "Moving down past EOF
+                call append(line('$'), '')
             endif
             normal! gvxjPgvjojo
             "}}}
-        elseif a:dir ==? "right" "{{{ Right
+        elseif a:dir ==? 'right' "{{{ Right
             normal! gvxpgvlolo
             "}}}
-        elseif a:dir ==? "left" "{{{ Left
+        elseif a:dir ==? 'left' "{{{ Left
             if l:left_col == 1
                 execute "normal! gvA \<esc>"
                 if g:Schlepp#allowSquishingBlock || match(getline(l:fline, l:lline), '^[^ \t]') == -1
                     for l:linenum in range(l:fline, l:lline)
                         if match(getline(l:linenum), "^[ \t]") != -1
-                            call setline(l:linenum, substitute(getline(l:linenum), "^\\s", "", ""))
-                            execute "normal! :" . l:linenum . "\<cr>" . l:right_col . "|a \<esc>"
+                            call setline(l:linenum, substitute(getline(l:linenum), "^\\s", '', ''))
+                            execute 'normal! :' . l:linenum . "\<cr>" . l:right_col . "|a \<esc>"
                         endif
                     endfor
                 endif
@@ -202,14 +202,14 @@ function! s:SchleppBlock(dir)
                 let l:right_col -= 1
             endif
             for l:linenum in range(l:fline, l:lline)
-                call setline(l:linenum, substitute(getline(l:linenum), "\\s\\+$", "", ""))
+                call setline(l:linenum, substitute(getline(l:linenum), "\\s\\+$", '', ''))
             endfor
             "Take care of trailing space created on lines above or below while
             "moving past them
-            if a:dir ==? "up"
-                call setline(l:lline + 1, substitute(getline(l:lline + 1), "\\s\\+$", "", ""))
-            elseif a:dir ==? "down"
-                call setline(l:fline - 1, substitute(getline(l:fline - 1), "\\s\\+$", "", ""))
+            if a:dir ==? 'up'
+                call setline(l:lline + 1, substitute(getline(l:lline + 1), "\\s\\+$", '', ''))
+            elseif a:dir ==? 'down'
+                call setline(l:fline - 1, substitute(getline(l:fline - 1), "\\s\\+$", '', ''))
             endif
         endif
 
@@ -229,8 +229,8 @@ endfunction "}}}
 "}}}
 "{{{ Schlepp Duplication
 "{{{ User Config
-let g:Schlepp#dupLinesDir = get(g:, 'Schlepp#dupLinesDir', "down")
-let g:Schlepp#dupBlockDir = get(g:, 'Schlepp#dupBlockDir', "right")
+let g:Schlepp#dupLinesDir = get(g:, 'Schlepp#dupLinesDir', 'down')
+let g:Schlepp#dupBlockDir = get(g:, 'Schlepp#dupBlockDir', 'right')
 let g:Schlepp#dupTrimWS = get(g:, 'Schlepp#dupTrimWS', 0)
 ""}}}
 "{{{ Mappings
@@ -251,7 +251,7 @@ function! s:SchleppDup(...) range
 " Duplicates the selected lines/block of text
 
     "Get mode
-    normal gv
+    normal! gv
     let l:md = mode()
     execute "normal! \<Esc>"
 
@@ -263,7 +263,7 @@ function! s:SchleppDup(...) range
     endif
 
     "Branching to other functions for lines and blocks
-    if l:md ==# "V"
+    if l:md ==# 'V'
         "Get direction
         if a:0 >= 1
             let l:dir = a:1
@@ -271,13 +271,13 @@ function! s:SchleppDup(...) range
             let l:dir = g:Schlepp#dupLinesDir
         endif
 
-        if l:dir ==? "up" || l:dir ==? "down"
+        if l:dir ==? 'up' || l:dir ==? 'down'
             call s:SchleppDupLines(l:dir)
         else
             call s:ResetSelection()
-            echom "Left and Right duplication not supported for lines"
+            echom 'Left and Right duplication not supported for lines'
         endif
-    elseif l:md ==# ""
+    elseif l:md ==# ''
         "Get direction
         if a:0 >= 1
             let l:dir = a:1
@@ -291,16 +291,16 @@ endfunction "}}}
 "{{{ s:SchleppDupLines(dir)
 function! s:SchleppDupLines(dir)
 "  Logic for duplicating line selections
-    if a:dir ==? "up"
-        let l:reselect = "gv"
-    elseif a:dir ==? "down"
+    if a:dir ==? 'up'
+        let l:reselect = 'gv'
+    elseif a:dir ==? 'down'
         let l:reselect = "'[V']"
     else
         call s:ResetSelection()
         return
     endif
 
-    execute "normal! gvyP" . l:reselect
+    execute 'normal! gvyP' . l:reselect
 endfunction "}}}
 "{{{ s:SchleppDupBlock(dir)
 function! s:SchleppDupBlock(dir)
@@ -310,36 +310,40 @@ function! s:SchleppDupBlock(dir)
         setlocal virtualedit=all
         let [l:fbuf, l:fline, l:fcol, l:foff] = getpos("'<")
         let [l:lbuf, l:lline, l:lcol, l:loff] = getpos("'>")
-        let [l:left_col, l:right_col]  = sort([l:fcol + l:foff, l:lcol + l:loff], "s:NrCmp")
+        let [l:left_col, l:right_col]  = sort([l:fcol + l:foff, l:lcol + l:loff], 's:NrCmp')
         if &selection ==# "exclusive" && l:fcol + l:foff < l:lcol + l:loff
             let l:right_col -= 1
         endif
         let l:numlines = (l:lline - l:fline) + 1
         let l:numcols = (l:right_col - l:left_col)
 
-        if a:dir ==? "up"
+        if a:dir ==? 'up'
             if (l:fline - l:numlines) < 1
                 "Insert enough lines to duplicate above
-                for i in range((l:numlines - l:fline) + 1)
-                    call append(0, "")
+                for l:i in range((l:numlines - l:fline) + 1)
+                    call append(0, '')
                 endfor
                 "Position of selection has changed
                 let [l:fbuf, l:fline, l:fcol, l:foff] = getpos("'<")
             endif
 
-            let l:set_cursor = ":call cursor(getpos(\"'<\")[1:3])\<CR>" . l:numlines . "k"
-            execute "normal! gvy" . l:set_cursor . "Pgv"
+            let l:set_cursor = ":call cursor(getpos(\"'<\")[1:3])\<CR>" . l:numlines . 'k'
+            execute 'normal! gvy' . l:set_cursor . 'Pgv'
 
-        elseif a:dir ==? "down"
+        elseif a:dir ==? 'down'
             if l:lline + l:numlines >= line('$')
-                for i in range((l:lline + l:numlines) - line('$'))
-                    call append(line('$'), "")
+                for l:i in range((l:lline + l:numlines) - line('$'))
+                    call append(line('$'), '')
                 endfor
             endif
-            execute "normal! gvy'>j" . l:left_col . "|Pgv"
-        elseif a:dir ==? "left"
-            execute "normal! gvyP" . l:numcols . "l\<C-v>" . (l:numcols + (&selection ==# 'exclusive')) . "l" . (l:numlines - 1) . "jo"
-        elseif a:dir ==? "right"
+            execute "normal! gvy'>j" . l:left_col . '|Pgv'
+        elseif a:dir ==? 'left'
+            if l:numcols > 0
+                execute 'normal! gvyP' . l:numcols . "l\<C-v>" . (l:numcols + (&selection ==# 'exclusive')) . 'l' . (l:numlines - 1) . 'jo'
+            else
+                execute "normal! gvyP\<C-v>"  . (l:numlines - 1) . 'jo'
+            endif
+        elseif a:dir ==? 'right'
             normal! gvyPgv
         else
             call s:ResetSelection()
@@ -356,7 +360,7 @@ function! s:SchleppDupBlock(dir)
             endif
             for l:linenum in range(l:fline, l:lline)
                 if l:right_col == len(getline(l:linenum))
-                    call setline(l:linenum, substitute(getline(l:linenum), "\\s\\+$", "", ""))
+                    call setline(l:linenum, substitute(getline(l:linenum), "\\s\\+$", '', ''))
                 endif
             endfor
         endif
@@ -368,7 +372,7 @@ endfunction "}}}
 "{{{ Utility Functions
 "{{{ s:CheckUndo(md)
 function! s:CheckUndo(md)
-    if !exists("b:schleppState")
+    if !exists('b:schleppState')
         let b:schleppState = {}
         let b:schleppState.lastNr = undotree().seq_last
         let b:schleppState.lastMd = a:md
@@ -387,7 +391,7 @@ endfunction
 "}}}
 "{{{ s:ResetSelection()
 function! s:ResetSelection()
-    execute "normal \<Esc>gv"
+    execute "normal! \<Esc>gv"
 endfunction
 "}}}
 "{{{ s:NrCmp(i1, i2)
@@ -402,7 +406,7 @@ if exists('*shiftwidth')
     endfunction
 else
     function s:sw()
-        return &sw
+        return &shiftwidth
     endfunction
 endif
 "}}}


### PR DESCRIPTION
I apologize for the number of changes.  I had corrected all VINT (vim lint) errors, and some were real (failed to scope l:linenum on line 126, and the use of 'normal cmd' should be 'normal! cmd' to avoid user mappings being triggerred.)

The real issue is on line 341 where a (in inclusive mode) a single character wide selection resulting in corruption.  It worked find for SchleppDupBlock('right') but failed for SchleppDupBlock('left')

Regards
